### PR TITLE
fix(cli): post install warnings are not clearly visible when running …

### DIFF
--- a/packages/aws-cdk/lib/init.ts
+++ b/packages/aws-cdk/lib/init.ts
@@ -241,15 +241,16 @@ async function initializeProject(template: InitTemplate, language: string, canUs
   await assertIsEmptyDirectory(workDir);
   print(`Applying project template ${colors.green(template.name)} for ${colors.blue(language)}`);
   await template.install(language, workDir);
+  if (await fs.pathExists('README.md')) {
+    print(colors.green(await fs.readFile('README.md', { encoding: 'utf-8' })));
+  }
+
   if (!generateOnly) {
     await initializeGitRepository(workDir);
     await postInstall(language, canUseNetwork, workDir);
   }
-  if (await fs.pathExists('README.md')) {
-    print(colors.green(await fs.readFile('README.md', { encoding: 'utf-8' })));
-  } else {
-    print('✅ All done!');
-  }
+
+  print('✅ All done!');
 }
 
 async function assertIsEmptyDirectory(workDir: string) {
@@ -292,7 +293,7 @@ async function postInstallTypescript(canUseNetwork: boolean, cwd: string) {
   const command = 'npm';
 
   if (!canUseNetwork) {
-    print(`Please run ${colors.green(`${command} install`)}!`);
+    warning(`Please run '${command} install'!`);
     return;
   }
 
@@ -300,28 +301,36 @@ async function postInstallTypescript(canUseNetwork: boolean, cwd: string) {
   try {
     await execute(command, ['install'], { cwd });
   } catch (e) {
-    throw new Error(`${colors.green(`${command} install`)} failed: ` + e.message);
+    warning(`${command} install failed: ` + e.message);
   }
 }
 
 async function postInstallJava(canUseNetwork: boolean, cwd: string) {
+  const mvnPackageWarning = 'Please run \'mvn package\'!';
   if (!canUseNetwork) {
-    print(`Please run ${colors.green('mvn package')}!`);
+    warning(mvnPackageWarning);
     return;
   }
 
-  print(`Executing ${colors.green('mvn package')}...`);
-  await execute('mvn', ['package'], { cwd });
+  print('Executing \'mvn package\'');
+  try {
+    await execute('mvn', ['package'], { cwd });
+  } catch (e) {
+    warning('Unable to package compiled code as JAR');
+    warning(mvnPackageWarning);
+  }
+
 }
 
 async function postInstallPython(cwd: string) {
   const python = pythonExecutable();
+  warning(`Please run ${python} -m venv .env'!`);
   print(`Executing ${colors.green('Creating virtualenv...')}`);
   try {
     await execute(python, ['-m venv', '.env'], { cwd });
   } catch (e) {
-    print('Unable to create virtualenv automatically');
-    print(`Please run ${colors.green(python + ' -m venv .env')}!`);
+    warning('Unable to create virtualenv automatically');
+    warning(`Please run '${python} -m venv .env'!`);
   }
 }
 


### PR DESCRIPTION
…cdk init (#8723)

Modified initialization of git and post install steps to the end of the init process.
Changed the current messages to use `warning` which will display them in yellow
and updated guidance text.

Closes #8720

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
